### PR TITLE
Fixed comparison of integers of different signs warning

### DIFF
--- a/SHA-3/Keccak.cpp
+++ b/SHA-3/Keccak.cpp
@@ -150,7 +150,7 @@ void KeccakBase::addData(const uint8_t *input, unsigned int off, unsigned int le
 {
 	while (len > 0) 
 	{
-		int cpLen = 0;
+		unsigned int cpLen = 0;
 		if((blockLen - bufferLen) > len)
 		{
 			cpLen = len;


### PR DESCRIPTION
Local variable cpLen in addData is declared as int, while the other integers in addData are unsigned int.
It is never set to a negative value because it is 0 by default, and set to either len, which is unsigned, or blockLen - bufferLen, where bufferLen is never larger than blocLen.
It is then compared to i, which is unsigned int, in the for loop.
All the member variables of KeccakBase are also unsigned.